### PR TITLE
Fixed TS imports breaking without semicolon

### DIFF
--- a/packages/import-cost/src/tsParser.js
+++ b/packages/import-cost/src/tsParser.js
@@ -16,7 +16,7 @@ function gatherPackages(sourceFile) {
       const packageInfo = {
         name: importNode.moduleSpecifier.text,
         line: sourceFile.getLineAndCharacterOfPosition(importNode.getStart()).line + 1,
-        string: `${importNode.getText()} console.log(${importNode.importClause.getText().replace('* as ', '')});`
+        string: `${importNode.getText()}; console.log(${importNode.importClause.getText().replace('* as ', '')});`
       };
       packages.push(packageInfo);
     } else if (node.kind === ts.SyntaxKind.CallExpression) {


### PR DESCRIPTION
Before the change:
```ts
import * as lodash from 'lodash'; console.log('...') // works
import * as lodash from 'lodash' console.log('...')  // breaks
```
After the change:
```ts
import * as lodash from 'lodash';; console.log('...') // works
import * as lodash from 'lodash'; console.log('...')  // works
```

Alternatives:
- Use `importNode.getText().replace(/;?$/, ';')` to add a semi if there isn't one, and do nothing if there is one
- Use `\n` instead of `;`

The alternatives might be more "proper", but throwing a semi in there seems to work just fine.

Fixes https://github.com/wix/import-cost/issues/17