### PR TITLE
Bundle with NODE_ENV set to 'production'

### DIFF
--- a/packages/import-cost/src/webpack.js
+++ b/packages/import-cost/src/webpack.js
@@ -27,6 +27,9 @@ function calcSize(packageInfo, callback) {
   const compiler = webpack({
     entry: entryPoint.name,
     plugins: [
+      new webpack.DefinePlugin({
+        'process.env.NODE_ENV': JSON.stringify('production')
+      }),
       new webpack.optimize.ModuleConcatenationPlugin(),
       new webpack.IgnorePlugin(/^electron$/),
       new BabiliPlugin()


### PR DESCRIPTION
It makes more sense for the import-cost extension to report production-mode filesizes rather than dev-mode

Fixes #41