### PR TITLE
Add support for import module = require("module")

### DIFF
--- a/packages/import-cost/src/tsParser.js
+++ b/packages/import-cost/src/tsParser.js
@@ -60,6 +60,16 @@ function gatherPackages(sourceFile) {
         string: importStatement
       };
       packages.push(packageInfo);
+    } else if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference) &&
+               node.moduleReference.expression && ts.isStringLiteral(node.moduleReference.expression)) {
+      const packageName = node.moduleReference.expression.text;
+      const packageInfo = {
+        fileName: sourceFile.fileName,
+        name: packageName,
+        line: sourceFile.getLineAndCharacterOfPosition(node.moduleReference.getStart()).line + 1,
+        string: `const aaa = require('${packageName}')`
+      };
+      packages.push(packageInfo);
     } else if (ts.isCallExpression(node)) {
       const callExpressionNode = node;
       if (callExpressionNode.expression.text === 'require') {

--- a/packages/import-cost/test/fixtures/import-require.ts
+++ b/packages/import-cost/test/fixtures/import-require.ts
@@ -1,0 +1,2 @@
+import aaa = require('chai');
+console.log(aaa);

--- a/packages/import-cost/test/index.spec.js
+++ b/packages/import-cost/test/index.spec.js
@@ -72,6 +72,7 @@ describe('importCost', () => {
   it('calculates size of template require in typescript', () => test('require-template.ts'));
   it('calculates size of import in javascript', () => test('import.js'));
   it('calculates size of import in typescript', () => test('import.ts'));
+  it('calculates size of import require in typescript', () => test('import-require.ts'));
   it('calculates size of aliased import in javascript', () => test('import-aliased.js'));
   it('calculates size of aliased import in typescript', () => test('import-aliased.ts'));
   it('calculates size of import with no semicolon in typescript', () => test('import-no-semicolon.ts'));


### PR DESCRIPTION
TypeScript has a specific kind of import:

```TS
import module = require("module") 
```

More info: https://www.typescriptlang.org/docs/handbook/modules.html

This PR adds support for that syntax.