### PR TITLE
Add a link to vim-import-cost in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Enjoy!
 
 * [Jetbrains IDE Plugin](https://github.com/denofevil/import-cost)
 * [Atom Package](https://atom.io/packages/import-cost-atom)
+* [Vim Plugin](https://github.com/yardnsm/vim-import-cost)
 
 
 ## Why & How


### PR DESCRIPTION
Hi, awesome work on this plugin :)

I created a Vim version of this plugin (https://github.com/yardnsm/vim-import-cost). This PR adds a link to it.

Thanks!