### PR TITLE
bug: Fixes prepublish script in coc and vs plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "precommit": "lerna run precommit",
-    "postinstall": "lerna bootstrap --loglevel verbose",
+    "postinstall": "lerna link && lerna exec -- npm i && lerna bootstrap --loglevel verbose",
     "test": "lerna run test"
   },
   "devDependencies": {

--- a/packages/coc-import-cost/package.json
+++ b/packages/coc-import-cost/package.json
@@ -73,7 +73,7 @@
     "compile": "tslint {src,test}/**/*.ts && tsc -watch -p ./",
     "pretest": "npm run coc:prepublish",
     "precommit": "npm run coc:prepublish",
-    "prebublish": "npm run coc:prepublish",
+    "prepublish": "npm run coc:prepublish",
     "test": ":",
     "build": ":"
   },

--- a/packages/vscode-import-cost/package.json
+++ b/packages/vscode-import-cost/package.json
@@ -109,7 +109,7 @@
     "postinstall": "node ./node_modules/vscode/bin/install",
     "pretest": "npm run vscode:prepublish",
     "precommit": "npm run vscode:prepublish",
-    "prebublish": "npm run vscode:prepublish",
+    "prepublish": "npm run vscode:prepublish",
     "test": "node ./node_modules/vscode/bin/test",
     "build": ":"
   },


### PR DESCRIPTION

Fixed the typo in prepublish script in coc-import-cost plugin and
vscode-import-cost plugin.

Tested by locally installing the coc-import-cost plugin. It was not
creating `lib` directory earlier but after fixing the typo it stated
working.

After fixing typo the build starting failing because both the plugins
were dependent on import-cost plugin. Updated the postinstall script to
run install command on all packages first and then run bootstrap.

Reference for failed build:
https://ci.appveyor.com/project/shahata/import-cost/builds/33107766
