### PR TITLE
bump parser deps

### DIFF
--- a/packages/import-cost/package.json
+++ b/packages/import-cost/package.json
@@ -38,11 +38,11 @@
     "yoshi": "^3.20.2"
   },
   "dependencies": {
-    "@babel/core": "^7.0.0",
-    "@babel/parser": "^7.0.0",
-    "@babel/runtime": "^7.0.0",
-    "@babel/traverse": "^7.0.0",
-    "@babel/types": "^7.0.0",
+    "@babel/core": "^7.12.9",
+    "@babel/parser": "^7.12.7",
+    "@babel/runtime": "^7.12.5",
+    "@babel/traverse": "^7.12.9",
+    "@babel/types": "^7.12.7",
     "babili-webpack-plugin": "^0.1.2",
     "css-loader": "^0.28.4",
     "file-loader": "^0.11.2",

--- a/packages/vscode-import-cost/package.json
+++ b/packages/vscode-import-cost/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "filesize": "^3.5.10",
-    "import-cost": "^1.8.0"
+    "import-cost": "^1.9.0"
   },
   "icon": "images/import-cost-logo.png",
   "galleryBanner": {


### PR DESCRIPTION
Resolves #185

There are some new language features in more recent versions of Babel that currently break this extension. We just need these deps to get a bump to support them