### PR TITLE
bug: Fix errors on libraries that starts with @

### DIFF
--- a/packages/import-cost/src/webpack.js
+++ b/packages/import-cost/src/webpack.js
@@ -68,6 +68,7 @@ function calcSize(packageInfo, callback) {
     externals,
     output: {
       filename: 'bundle.js',
+      libraryTarget: 'commonjs2',
     },
   });
 


### PR DESCRIPTION
This PR is an attempt at fixing some of the errors related to libraries starting with `@` as seen In #165  and #113. 

The error in question is : 
```
"error": {
      "err": [
        "unknown: Unexpected token (91:17)",
        "bundle.js from Terser\nUnexpected character '@' [bundle.js:91,17]"
      ]
    }
```
Upon some investigation, I stumble into these 2 posts that hinted that `commonjs2` should be used when working with libraries that start with `@`

https://github.com/webpack/webpack/issues/1114#issuecomment-656190939
https://stackoverflow.com/questions/58105364/add-dependency-to-externals-with-in-the-library-name

And it did the trick
Before 
<img width="810" alt="Screen Shot 2020-12-02 at 1 53 01 AM" src="https://user-images.githubusercontent.com/17114134/100844242-344e5700-3441-11eb-8530-d5c3c6be7338.png">
After
<img width="797" alt="Screen Shot 2020-12-02 at 1 30 25 AM" src="https://user-images.githubusercontent.com/17114134/100844249-37494780-3441-11eb-92ed-ff269a5acb0d.png">

@shahata 