### PR TITLE
fix: freeze webpack version from "^5" to "5.19.0"

### DIFF
--- a/packages/import-cost/package.json
+++ b/packages/import-cost/package.json
@@ -52,7 +52,7 @@
     "pkg-dir": "^2.0.0",
     "tempy": "^0.2.1",
     "url-loader": "^0.5.9",
-    "webpack": "^5",
+    "webpack": "5.19.0",
     "worker-farm": "^1.4.1"
   },
   "publishConfig": {


### PR DESCRIPTION
fix #165

tested OK with my private packages [@cjy0208/import-cost](https://www.npmjs.com/package/@cjy0208/import-cost)