### PR TITLE
fix: Parameter decorator bug parsing typescript

### DIFF
--- a/packages/import-cost/src/babel-parser.js
+++ b/packages/import-cost/src/babel-parser.js
@@ -10,7 +10,7 @@ const PARSE_PLUGINS = [
   'doExpressions',
   'trailingFunctionCommas',
   'objectRestSpread',
-  ['decorators', { decoratorsBeforeExport: true }],
+  'decorators-legacy',
   'classProperties',
   'exportExtensions',
   'exponentiationOperator',


### PR DESCRIPTION
- Using the old "decorators" plugin config was preventing import-cost to parse decorators in class constructors parameters.
- Followed babel guidelines to replace the old plugin by the latest `decorators-legacy`
