### PR TITLE
fix: vsce packaging failing on ci

### DIFF
--- a/packages/vscode-import-cost/package.json
+++ b/packages/vscode-import-cost/package.json
@@ -160,7 +160,7 @@
     ]
   },
   "scripts": {
-    "pretest": "webpack -c ./webpack.browser.js && webpack -c ./webpack.electron.js",
+    "pretest": "webpack -c ./webpack.browser.js && webpack -c ./webpack.electron.js && vsce package -o dist --yarn",
     "test": "node ./test/index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
I realised that it was tried several times to add the `vsce package` step to the `pretest` script.
Like in the commits: 2117d6a4cd3fc0f8ef5cff41811f9aba61d825e4, 328a68fadfb1cdaece0cacd9e164cbd9f45a10e8 and 328a68fadfb1cdaece0cacd9e164cbd9f45a10e8

Referring to https://stackoverflow.com/questions/70526178/error-package-vscode-extension-with-vsce-invalid-relative-path

It is easily solvable by adding the `--yarn` modifier, even if yarn is not installed in the system (I tested it)

So maybe this is a useful add-on to the build system, at least I hope so, feel free to discard this PR if I am wrong.