### PR TITLE
Noting output coloration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The extension utilizes webpack in order to detect the imported size.
 
 ![Example Image](https://citw.dev/_next/image?url=%2Fposts%2Fimport-cost%2F1quov3TFpgG2ur7myCLGtsA.gif&w=1080&q=75)
 
+The output will be colored according to the package size - large, medium, or small. Thresholds can be found in the settings.
+
 This project includes implementation of:
  * Import Cost [VSCode extension](packages/vscode-import-cost) - install it from [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)
  * Import Cost [Node module](packages/import-cost) - use freely to implement extensions for other IDE (or contribute them to this repository)


### PR DESCRIPTION
The current docs don't mention what the different coloration of the output means. It took me a second to figure out. Seems nice to just mention it in the docs, as it's kind of a nice feature of the extension.